### PR TITLE
Log sync key in spike generation node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # brand-simulator
 BRAND module for neural simulator
 
-![image](https://user-images.githubusercontent.com/11467761/184686652-5224d80c-2a1d-45ed-bfe8-79aec0d3c339.png)
-
 ## How to use
 
 The simulator is run using [BRAND](https://github.com/snel-repo/realtime_rig_dev/tree/dev). This will require first running the setup within the BRAND directory:

--- a/nodes/thresholds_udp/thresholds_udp.py
+++ b/nodes/thresholds_udp/thresholds_udp.py
@@ -1,13 +1,17 @@
 
 import gc
+import json
 import logging
 import os
 import signal
+import socket
 import sys
 import time
-import socket
+
 import numpy as np
+
 from brand import BRANDNode
+
 
 class SpikeGenerator(BRANDNode):
     def __init__(self):
@@ -102,6 +106,7 @@ class SpikeGenerator(BRANDNode):
 
         self.last_time = time.monotonic()
 
+        sync_dict = {'count': 0}
         # send samples to Redis
         while True:
             self.sample['ts_start'] = time.monotonic()
@@ -132,6 +137,8 @@ class SpikeGenerator(BRANDNode):
                     time.sleep(1e-6)
 
                 self.sample['ts'] = time.monotonic()
+                sync_dict['count'] += 1
+                self.sample['sync'] = json.dumps(sync_dict)
                 self.r.xadd(self.output_stream, self.sample, maxlen=self.max_samples, approximate=True)
                 
                 self.sample['ts_end'] = time.monotonic()


### PR DESCRIPTION
The `bin_multiple` node in the `cursor-control` module expects a key named "sync" to be in each incoming stream entry. This PR adds the "sync" key to the output of the `thresholds_udp` node. It can be tested by running the [01_calibration.ipynb](https://github.com/brandbci/brand-tutorial/blob/main/notebooks/01_calibration.ipynb) notebook in `brand-tutorial`.